### PR TITLE
github action gitspell

### DIFF
--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -1,2 +1,3 @@
 gitlint
+gitspell
 shellcheck

--- a/.github/actions/gitspell/action.yml
+++ b/.github/actions/gitspell/action.yml
@@ -1,0 +1,18 @@
+---
+name: 'gitspell'
+description:
+  'Checks spelling of all commit messages'
+outputs:
+  diagnostic:
+    description: 'Diagnostic text for gitspell'
+    value: ${{ steps.gitspell-step.outputs.diagnostic }}
+runs:
+  using: 'composite'
+  steps:
+    - run: sudo npm install -g cspell@latest
+      shell: bash
+    - id: gitspell-step
+      run: >
+        ./scripts/out_wrapper.sh ./scripts/gitspell.sh diagnostic
+        &> $GITHUB_OUTPUT
+      shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,18 @@ jobs:
           printf ${{ toJSON(steps.gitlint-step.outputs.diagnostic) }}
           >> $GITHUB_STEP_SUMMARY
         if: always()
+  gitspell:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # fetch everything
+      - id: gitspell-step
+        uses: ./.github/actions/gitspell
+      - run: >
+          printf ${{ toJSON(steps.gitspell-step.outputs.diagnostic) }}
+          >> $GITHUB_STEP_SUMMARY
+        if: always()
   yamllint:
     runs-on: ubuntu-latest
     steps:

--- a/scripts/gitspell.sh
+++ b/scripts/gitspell.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -e
+printf "cspell version %s\n" "$(cspell --version)"
+git log | cspell stdin -c ./.cspell/cspell.config.yaml --no-progress --no-summary --show-context --show-suggestions --no-cache


### PR DESCRIPTION
Add a github action, that checks the entire git log of the current tree for spelling mistakes using `cspell`. It uses the same config as the project content (project-words etc.).